### PR TITLE
Nettoie histogramme des classes maximales

### DIFF
--- a/index.html
+++ b/index.html
@@ -144,7 +144,7 @@
 <!-- <div class="chart-wrapper"><h3>Répartition des classes (exercice sélectionné)</h3><canvas id="classPieChart"  class="pie"></canvas></div> -->
 <!-- <div class="chart-wrapper"><h3>Classe moyenne globale vs temps</h3><canvas id="globalClassChart" class="plot"></canvas></div> -->
 <!-- <div class="chart-wrapper"><h3>Répartition des tests par exercice</h3><canvas id="timeExerciseChart" class="pie"></canvas></div> -->
-<div class="chart-wrapper"><h3>Classe moyenne & classe maximale par exercice</h3><canvas id="exStatsChart" class="plot"></canvas></div>
+<div class="chart-wrapper"><h3>Classe maximale par exercice</h3><canvas id="exStatsChart" class="plot"></canvas></div>
 <div class="chart-legend-container">
   <!-- Cloner la légende -->
   <div id="legend-for-exStatsChart"></div>
@@ -395,28 +395,23 @@ function refresh(){
   ));
 
   /* ---------- stats par exercice ---------- */
-  const byEx={};
-  data.forEach(d=>{
-    byEx[d.test] ??= {sum:0,cnt:0,max:0};
-    byEx[d.test].sum += d.cls;
-    byEx[d.test].cnt ++;
-    byEx[d.test].max = Math.max(byEx[d.test].max,d.cls);
+  const byEx = {};
+  data.forEach(d => {
+    byEx[d.test] ??= { cnt: 0, max: 0 };
+    byEx[d.test].cnt++;
+    byEx[d.test].max = Math.max(byEx[d.test].max, d.cls);
   });
   const exLabels = Object.keys(byEx).sort();
-  const clsAvg   = exLabels.map(k => +(byEx[k].sum / byEx[k].cnt).toFixed(2));
-  const clsMax   = exLabels.map(k=> byEx[k].max );
-  const attempts = exLabels.map(k=> byEx[k].cnt );
+  const clsMax   = exLabels.map(k => byEx[k].max );
+  const attempts = exLabels.map(k => byEx[k].cnt );
 
-  /* Histogramme : classe moyenne & classe maximale */
+  /* Histogramme : classe maximale */
   charts.push(new Chart(
     document.getElementById('exStatsChart'),{
       type:'bar',
       data:{
         labels: exLabels,
         datasets:[
-          { label:'Classe moyenne',
-            data: clsAvg,
-            backgroundColor: '#bdc3c7' },
           { label:'Classe maximale',
             data: clsMax,
             backgroundColor: clsMax.map(v => CLASS_COLOR_MAP[v] || RED) }


### PR DESCRIPTION
## Summary
- supprime l'affichage de la classe moyenne pour l'histogramme par exercice
- met à jour le titre du graphique dans la page

## Testing
- `git diff --cached --shortstat`

------
https://chatgpt.com/codex/tasks/task_e_6862538496748330841dbe68a32d8a29